### PR TITLE
Add reference to the definition of JPEG 2000 codestreams early in the document

### DIFF
--- a/draft-ietf-avtcore-rtp-j2k-scl-05.xml
+++ b/draft-ietf-avtcore-rtp-j2k-scl-05.xml
@@ -65,7 +65,9 @@ docName="draft-ietf-avtcore-rtp-j2k-scl-05" xml:lang="en" version="3">
     <section>
       <name>Introduction</name>
       <t>This RTP payload format specifies the streaming of a video signal
-      encoded as a sequence of JPEG 2000 codestreams.</t>
+      encoded as a sequence of JPEG 2000 codestreams (see <xref
+      target="sec-media-description"/> for a primer on the structure of JPEG
+      2000 codestreams).</t>
 
       <t>In addition to supporting a variety of frame scanning techniques
       (progressive, interlaced and progressive segmented frame) and image
@@ -122,7 +124,7 @@ docName="draft-ietf-avtcore-rtp-j2k-scl-05" xml:lang="en" version="3">
       they appear in all capitals, as shown here.</t>
     </section>
 
-    <section>
+    <section anchor="sec-media-description">
       <name>Media format description</name>
       <t>The following summarizes the structure of the JPEG 2000 codestream,
       which is specified in detail at <xref target="jpeg2000-1"/>.</t>
@@ -275,9 +277,6 @@ Packets |        Main         | Body | ... |    Body   | Main ...
 
         <t>NOTE: Padding bytes can be used to achieve constant bit rate
         transmission.</t>
-
-        <t> A JPEG 2000 codestream consists of the bytes between, and including,
-        the SOC and EOC markers, as defined in <xref target="jpeg2000-1"/>.</t>
 
         <t>A JPEG 2000 codestream fragment does not necessarily contain complete
         JPEG 2000 packets, as defined in <xref target="jpeg2000-1"/>.</t>
@@ -783,9 +782,12 @@ Packets |        Main         | Body | ... |    Body   | Main ...
     </section>
 
     <section anchor="sec-codestream">
-      <name>JPEG 2000 codestream requirements</name>
+      <name>JPEG 2000 codestream</name>
       <section>
         <name>General</name>
+        <t> A JPEG 2000 codestream consists of the bytes between, and including,
+        the SOC and EOC markers, as defined in <xref target="jpeg2000-1"/>.</t>
+
         <t>The JPEG 2000 codestream MAY include capabilities beyond those
         specified at <xref target="jpeg2000-1"/>, including those specified in
         <xref target="jpeg2000-2"/> and <xref target="jpeg2000-15"/>.</t>


### PR DESCRIPTION
Closes #6 